### PR TITLE
Added sample repository configuration for Maven projects deploying to the Alfresco Artifacts Repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,5 +75,18 @@
 			<version>3.1.2.RELEASE</version>
 			</dependency> 
 	</dependencies>
+        <distributionManagement>
+            <repository>
+                <id>alfresco-artifacts</id>
+                <name>Alfresco Share Extras Release Repository</name>
+                <url>https://artifacts.alfresco.com/nexus/content/repositories/share-extras</url>
+                <layout>default</layout>
+            </repository>
+            <snapshotRepository>
+                <id>alfresco-artifacts-snapshots</id>
+                <name>Alfresco Share Extras Snapshot Repository</name>
+                <url>https://artifacts.alfresco.com/nexus/content/repositories/share-extras-snapshots</url>
+            </snapshotRepository>
+  </distributionManagement>
 
 </project>


### PR DESCRIPTION
Created support repos and roles and tested SNAPSHOT deployment (see https://artifacts.alfresco.com/nexus/index.html#nexus-search;quick~share-oauth).

With the provided configuration and matching credentials in ~/.m2/settings.xml, a 'mvn deploy' will suffice to publish the artifacts.

If the version is set to release, release repo will be used automaticall.y
